### PR TITLE
Python 3 support and cli options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML
+pexpect

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Topic :: System :: Distributed Computing"
     ],
     entry_points={
@@ -56,4 +58,8 @@ setup(
             'spielbash = spielbash:main'],
     },
     include_package_data=True,
+    install_requires=[
+        'pyyaml',
+        'pexpect'
+    ],
 )

--- a/spielbash/__init__.py
+++ b/spielbash/__init__.py
@@ -141,7 +141,7 @@ class Scene(BaseAction):
         buffer = subprocess.Popen(['tmux', 'show-buffer'],
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE).communicate()[0]
-        return buffer
+        return str(buffer)
 
     def run(self):
         # replace vars if needed
@@ -175,7 +175,7 @@ class Movie:
         """shoot the movie."""
         self.reel = Command('tmux new-session -d -s %s' % self.session_name)
         # start filming
-        asciinema_cmd = 'asciinema rec -c "tmux attach -t %s" -y'
+        asciinema_cmd = 'asciinema rec -c "tmux attach -t %s" -y --overwrite'
         if self.script.get('title'):
             asciinema_cmd += ' -t %s' % pipes.quote(self.script.get('title'))
         asciinema_cmd += ' %s'

--- a/spielbash/__init__.py
+++ b/spielbash/__init__.py
@@ -15,6 +15,7 @@
 # under the License.
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import argparse
 import json
 import pipes
@@ -186,7 +187,7 @@ class Movie:
         # pause to make sure asciinema is ready
         pause(0.4)
         for scene in self.script['scenes']:
-            print "Rolling scene \"%s\"..." % scene['name'],
+            print('Rolling scene %r...' % scene['name'])
             s = None
             if 'action' in scene:
                 s = Scene(scene['name'], scene.get('action', ''),
@@ -204,7 +205,7 @@ class Movie:
                 sys.exit(1)
             if s:
                 s.run()
-            print " Cut !"
+            print(" Cut !")
             pause(READING_TIME)
         TmuxSendKeys(self.session_name, 'exit')
         TmuxSendKeys(self.session_name, 'C-m')
@@ -233,7 +234,7 @@ def main():
     # CAMERAS, LIGHTS AAAAAAAND ACTION !
     out, err = movie.shoot()
     if err:
-        print err
+        print(err)
     else:
         # set default width and height
         with open(output_file, 'r') as m:
@@ -244,9 +245,9 @@ def main():
             j['height'] = 25
         with open(output_file, 'w') as m:
             json.dump(j, m)
-        print "movie recorded as %s" % output_file
-        print "to replay: asciinema play %s" % output_file
-        print "to upload: asciinema upload %s" % output_file
+        print("movie recorded as", output_file)
+        print("to replay: asciinema play", output_file)
+        print("to upload: asciinema upload", output_file)
 
 
 if __name__ == '__main__':

--- a/spielbash/__init__.py
+++ b/spielbash/__init__.py
@@ -213,8 +213,9 @@ class Movie:
             print("\r Cut !")
             pause(READING_TIME * 2)
         TmuxSendKeys(self.session_name, 'exit\n')
-        TmuxSendKeys(self.session_name, 'C-d')
-        movie.expect(pexpect.EOF)
+        TmuxSendKeys(self.session_name, 'C-m')
+        self.reel.communicate('exit')
+        movie.kill(0)
 
 
 def strip_logout(lines):


### PR DESCRIPTION
Adds supports for python 3.5 and python 3.6. 
Adds supports for more cli options

- --speed: Typing speed
- --readtime: Reading Time - time to wait between scenes
- --width: Console width, defaults to 160
- --height: Console height, defaults to 60

Width and height are supported as described by JustinAzoff in issue #1 